### PR TITLE
Setup CI for compiling on multi-platform systems and run tests

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -24,8 +24,8 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        build_type: [Debug, RelWithDebInfo, Release]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest
@@ -37,12 +37,20 @@ jobs:
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
+          - os: macos-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: macos-latest
+            c_compiler: clang
+            cpp_compiler: clang++
         exclude:
           - os: windows-latest
             c_compiler: gcc
           - os: windows-latest
             c_compiler: clang
           - os: ubuntu-latest
+            c_compiler: cl
+          - os: macos-latest
             c_compiler: cl
 
     steps:
@@ -58,6 +66,10 @@ jobs:
     - name: Install ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install -y xorg-dev libglu1-mesa-dev
+
+    - name: Install macos dependencies
+      if: matrix.os == 'macos-latest'
+      run: brew install gcc llvm
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
This should prevent early compile error (on linux, windows, and macos) and runtime bugs that are caught by the tests.